### PR TITLE
sapfile: only display abbreviated file types with -l

### DIFF
--- a/sapfile
+++ b/sapfile
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-set -o errexit
 set -o nounset
 set -o pipefail
 
@@ -24,7 +23,7 @@ usage () {
    echo "Usage: sapfile [OPTION...] [FILE...]"
    echo "Determine type of SAP FILEs, optionally followed by type of FILEs."
    echo "  -h, --help                 display this help and exit"
-   echo "  -l                         long listing: also display the output of the plain file command for this FILE"
+   echo "  -l                         long listing: also display the file type, taken from the output of the file command"
    echo ""
    echo "Requires:"
    echo "- lsar (contained in the unar package from the EPEL RHEL repo)"
@@ -32,12 +31,12 @@ usage () {
    echo "- sapcar (SAP program to handle sapcar files; typical filename: SAPCAR_1115-70006178.EXE)"
 }
 
-_RUN_FILE_COMMAND="n"
+_EXTENDED_OUTPUT="n"
 
 while getopts ":lh" opt; do
    case ${opt} in
       l)
-         _RUN_FILE_COMMAND="y"
+         _EXTENDED_OUTPUT="y"
          ;;
       h)
          usage
@@ -52,14 +51,33 @@ while getopts ":lh" opt; do
 done
 shift "$((OPTIND-1))"
 
+_ARCHIVE_TYPE="other"
+
 for _FILE in "$@"; do
-   if [[ ${_RUN_FILE_COMMAND}. = "y." ]]; then
-      _FILE_OUTPUT=$(file "${_FILE}" | sed 's,'"${_FILE}"': ,,')
-      if [[ ${_FILE_OUTPUT}. == "data." ]] && [[ (${_FILE##*.} = "SAR" || ${_FILE##*.} = "sar") ]]; then
-         _FILE_OUTPUT="SAPCAR archive data - from file extension"
-      fi
+   _FILE_OUTPUT=$(file "${_FILE}" | sed 's,'"${_FILE}"': ,,')
+   if [[ ${_FILE_OUTPUT}. == "data." ]] && [[ (${_FILE##*.} == "SAR" || ${_FILE##*.} == "sar") ]]; then
+      _ARCHIVE_TYPE="sapcar"
+      _list_content="sapcar -tvf"
    else
-      _FILE_OUTPUT=""
+      _ARCHIVE_TYPE=$(echo ${_FILE_OUTPUT} | awk '
+      BEGIN{_file_type="other"}
+      /RAR self-extracting archive/{_file_type="rarexe"}
+      /RAR archive data/{_file_type="rar"}
+      /Zip archive data/{_file_type="zip"}
+      /SAPCAR archive data/{_file_type="sapcar"}
+      /directory/{_file_type="dir"}
+      END{print _file_type}')
+      if [[ ${_ARCHIVE_TYPE}. == "rarexe." ]]; then
+         _list_content="lsar"
+      elif [[ ${_ARCHIVE_TYPE}. == "rar." ]]; then
+         _list_content="lsar"
+      elif [[ ${_ARCHIVE_TYPE}. == "zip." ]]; then
+         _list_content="zipinfo -1"
+      elif [[ ${_ARCHIVE_TYPE}. == "sapcar." ]]; then
+         _list_content="sapcar -tvf"
+      elif [[ ${_ARCHIVE_TYPE}. == "dir." ]]; then
+         _list_content=""
+      fi
    fi
    printf "%-32s " "${_FILE}":
 
@@ -67,53 +85,36 @@ for _FILE in "$@"; do
       echo "No such file or directory."
       exit 1
    fi
-   if [[ -d "${_FILE}" ]]; then
-      _FILE_TYPE="directory"
-   else
-      _FILE_TYPE=$(echo "${_FILE}" | awk '
-      BEGIN{_sap_file_type="look_inside"}
-      /SAPCAR/&&/\.EXE/{_sap_file_type="sapcar"}
-      !/IMDB_SERVER/&&!/IMDB_CLIENT/&&/IMDB/&&/\.SAR/{_sap_file_type="sap_db_hana_other"}
-      /IMDB_SERVER/&&/\.SAR/{_sap_file_type="sap_db_hana"}
-      /IMDB_CLIENT/&&/\.SAR/{_sap_file_type="sap_db_hana_client"}
-      /SWPM/&&/\.SAR/{_sap_file_type="sap_swpm"}
-      /SAPHOSTAGENT/&&/\.SAR/{_sap_file_type="sap_hostagent"}
-      /igsexe/||/igshelper/{_sap_file_type="sap_igs"}
-      /SAPEXE_/||/SAPEXEDB_/{_sap_file_type="sap_kernel"}
-      /SAPWEBDISP_/{_sap_file_type="sap_webdisp"}
-      /SAPJVM/{_sap_file_type="sap_jvm"}
-      /ASEBC/{_sap_file_type="sap_db_ase_client"}
-      /COMPLETE/{_sap_file_type="sap_hana_backup"}
-      /S4/&&/HANA/&&/LANG/{_sap_file_type="sap_s4hana_lang"}
-      /S4/&&/EXPORT/{_sap_file_type="sap_s4hana_export"}
-      /BW4/&&/EXPORT/{_sap_file_type="sap_bw4hana_export"}
-      /VCH/&&/\.SAR/{_sap_file_type="sap_vch_afl"}
-      END{print _sap_file_type}')
-   fi
 
-   if [[ ${_FILE_TYPE}. != "look_inside." ]]; then
-      printf "%-24s%s\n" "${_FILE_TYPE}" "${_FILE_OUTPUT}"
-   else
-      _FILE_TYPE=$(file "${_FILE}" | awk '
-      BEGIN{_file_type="generic"}
-      /RAR self-extracting archive/||/RAR archive data/{_file_type="rar"}
-      /Zip archive data/{_file_type="zip"}
-      /SAPCAR archive data/{_file_type="sapcar"}
-      /directory/{_file_type="directory"}
-      END{print _file_type}')
-      if [[ ${_FILE_TYPE}. = "rar." ]]; then
-         _list_content="lsar"
-      elif [[ ${_FILE_TYPE}. = "zip." ]]; then
-         _list_content="zipinfo -1"
-      elif [[ ${_FILE_TYPE}. = "sapcar." ]]; then
-         _list_content="sapcar -tvf"
-      elif [[ ${_FILE_TYPE}. = "directory." ]]; then
-         printf "%-24s%s\n" "directory" "${_FILE_OUTPUT}"
-      elif [[ ${_FILE_TYPE}. = "generic." ]]; then
-         printf "%-24s%s\n" "sap_unknown" "${_FILE_OUTPUT}"
-      fi
+   SAP_FILE_TYPE_FROM_FILENAME=$(echo "${_FILE}" | awk '
+   BEGIN{_sap_file_type="look_inside"}
+   /SAPCAR/&&/\.EXE/{_sap_file_type="sapcar"}
+   !/IMDB_SERVER/&&!/IMDB_CLIENT/&&/IMDB/&&/\.SAR/{_sap_file_type="sap_db_hana_other"}
+   /IMDB_SERVER/&&/\.SAR/{_sap_file_type="sap_db_hana"}
+   /IMDB_CLIENT/&&/\.SAR/{_sap_file_type="sap_db_hana_client"}
+   /SWPM/&&/\.SAR/{_sap_file_type="sap_swpm"}
+   /SAPHOSTAGENT/&&/\.SAR/{_sap_file_type="sap_hostagent"}
+   /igsexe/||/igshelper/{_sap_file_type="sap_igs"}
+   /SAPEXE_/||/SAPEXEDB_/{_sap_file_type="sap_kernel"}
+   /SAPWEBDISP_/{_sap_file_type="sap_webdisp"}
+   /SAPJVM/{_sap_file_type="sap_jvm"}
+   /ASEBC/{_sap_file_type="sap_db_ase_client"}
+   /COMPLETE/{_sap_file_type="sap_hana_backup"}
+   /S4/&&/HANA/&&/LANG/{_sap_file_type="sap_s4hana_lang"}
+   /S4/&&/EXPORT/{_sap_file_type="sap_s4hana_export"}
+   /BW4/&&/EXPORT/{_sap_file_type="sap_bw4hana_export"}
+   /VCH/&&/\.SAR/{_sap_file_type="sap_vch_afl"}
+   END{print _sap_file_type}')
 
-      if [[ ${_FILE_TYPE}. != "directory." && ${_FILE_TYPE}. != "generic." ]]; then
+   if [[ ${SAP_FILE_TYPE_FROM_FILENAME}. != "look_inside." ]]; then
+      _SAP_FILE_TYPE=${SAP_FILE_TYPE_FROM_FILENAME}
+   else
+      if [[ ${_ARCHIVE_TYPE}. == "dir." ]]; then
+         _SAP_FILE_TYPE=${_FILE_OUTPUT}
+      elif [[ ${_ARCHIVE_TYPE}. == "rarexe." ||
+              ${_ARCHIVE_TYPE}. == "rar." ||
+              ${_ARCHIVE_TYPE}. == "zip." ||
+              ${_ARCHIVE_TYPE}. == "sapcar." ]]; then
          _SAP_FILE_TYPE=$(eval "${_list_content}" "${_FILE}" | awk '
          BEGIN{_sap_file_type="sap_unknown"}
          /BD_SYBASE_ASE/{_sap_file_type="sap_db_ase"}
@@ -128,8 +129,17 @@ for _FILE in "$@"; do
          /EXP[0-9]/{_sap_file_type="sap_ecc_ides_export"}
          /DATA_UNITS\/EXP[0-9]/{_sap_file_type="sap_nwas_abap_export"}
          /DATA_UNITS\/JAVA_EXPORT_JDMP/{_sap_file_type="sap_nwas_java_export"}
+         /format error in header/{_sap_file_type="format_error_in_header"}
          END{print _sap_file_type}')
-         printf "%-24s%s\n" "${_SAP_FILE_TYPE}" "${_FILE_OUTPUT}"
+      else
+         _SAP_FILE_TYPE="sap_unknown"
       fi
+   fi
+
+   printf "%-24s " "${_SAP_FILE_TYPE}"
+   if [[ ${_EXTENDED_OUTPUT}. == "y." ]]; then
+      printf "%s\n" "${_ARCHIVE_TYPE}"
+   else
+      printf "\n"
    fi
 done


### PR DESCRIPTION
We can make use of abbreviated file types for easy processing the files per file types