### PR TITLE
sapfile: simplify detection of sar files

### DIFF
--- a/sapfile
+++ b/sapfile
@@ -186,11 +186,11 @@ if [[ ${_DISPLAY_HEADER}. == "y." ]]; then
 fi
 
 for _FILE in "$@"; do
-   _FILE_OUTPUT=$(file "${_FILE}" | sed 's,'"${_FILE}"': ,,')
-   if [[ ${_FILE_OUTPUT}. == "data." ]] && [[ (${_FILE##*.} == "SAR" || ${_FILE##*.} == "sar") ]]; then
+   if [[ (${_FILE##*.} == "SAR" || ${_FILE##*.} == "sar") ]]; then
       _GENERIC_FILE_TYPE="sapcar"
       _list_content="${_SAPCAR_FILE} -tvf"
    else
+      _FILE_OUTPUT=$(file "${_FILE}" | sed 's,'"${_FILE}"': ,,')
       _GENERIC_FILE_TYPE=$(echo "${_FILE_OUTPUT}" | awk '
       BEGIN{_file_type="other"}
       /RAR self-extracting archive/{_file_type="rarexe"}


### PR DESCRIPTION
The file SWPM20SP16_0-80003424.SAR is detected by the file command, version 5.33 (as present in RHEL 8) as type "DIY-Thermocam raw data". So we better detect sapcar files only by looking at the file suffix.

See also https://github.com/sap-linuxlab/community.sap_install/issues/519